### PR TITLE
chore: add PR template with documentation checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses -->
+Closes #
+
+## Changes
+
+<!-- What does this PR do? -->
+- 
+
+## Documentation
+
+<!-- Check all that apply -->
+- [ ] No documentation needed (internal refactor, tests only, etc.)
+- [ ] Documentation added/updated in `apps/docs`
+- [ ] Documentation issue created for follow-up: #
+
+## Testing
+
+- [ ] Tests added/updated
+- [ ] Manually tested
+
+## Checklist
+
+- [ ] PR title follows conventional commits format
+- [ ] Code passes `pnpm health`
+- [ ] Related issue linked above


### PR DESCRIPTION
## Summary

Adds a pull request template that prompts contributors to:
- Link related issues
- Consider documentation needs
- Check off testing requirements

## Documentation

- [x] No documentation needed (this is a repo meta change)

## Checklist

- [x] PR title follows conventional commits format