### PR TITLE
fix: simplify vercel ignoreCommand path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "bash ../../scripts/vercel-ignore-build.sh || bash scripts/vercel-ignore-build.sh"
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
 }


### PR DESCRIPTION
## Problem

All Vercel deployments failing with:

```
✓ Code change detected: e2e/auth/tests/onboarding.e2e.ts
Proceeding with build
bash: scripts/vercel-ignore-build.sh: No such file or directory
```

## Root Cause

The `ignoreCommand` in `vercel.json` was:

```bash
bash ../../scripts/vercel-ignore-build.sh || bash scripts/vercel-ignore-build.sh
```

When the script exits with `1` (Vercel's "proceed with build" signal), bash treats it as a failure and runs the fallback command. The fallback path doesn't exist, causing the build to fail.

## Fix

Simplified to use the correct path directly:

```bash
bash scripts/vercel-ignore-build.sh
```

Vercel runs from the repo root, so this path is correct.

## Impact

This is blocking all PR deployments:
- #57
- #55
- #50
- #41