### PR TITLE
fix: correct path to vercel-ignore-build.sh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-build.sh"
 }


### PR DESCRIPTION
## Problem

Production deployments are failing:

```
bash: scripts/vercel-ignore-build.sh: No such file or directory
```

My previous fix (#60) broke this by changing the path from `../../scripts/` to `scripts/`.

## Root Cause

Vercel runs the `ignoreCommand` from the **app's root directory** (e.g., `apps/app`), not the repo root. So we need `../../scripts/vercel-ignore-build.sh` to reach the script.

The original command had:
```bash
bash ../../scripts/vercel-ignore-build.sh || bash scripts/vercel-ignore-build.sh
```

The `||` fallback was causing issues because when the script exits with `1` (Vercel's "proceed with build"), bash treats it as failure and runs the fallback.

## Fix

Use the correct path without the fallback:
```bash
bash ../../scripts/vercel-ignore-build.sh
```

## Prevention Suggestion

To prevent broken builds from being merged in the future:
1. Re-add Vercel deployment status as a required check in branch protection
2. Or add a "deployment-gate" workflow that fails if Vercel deployments fail

This ensures broken deployments can't be merged to main.